### PR TITLE
v1.4: Added parameter checks for commands

### DIFF
--- a/src/main/java/javacake/Parser.java
+++ b/src/main/java/javacake/Parser.java
@@ -37,15 +37,15 @@ public class Parser {
         String commandWord = buffer[0];
         helper(commandWord);
         switch (commandWord) {
-        case ("exit"): return new ExitCommand();
-        case ("list"): return new ListCommand();
-        case ("back"): return new BackCommand();
-        case ("score"): return new ScoreCommand();
-        case ("reset"): return new ResetCommand();
+        case ("exit"): return new ExitCommand(inputCommand);
+        case ("list"): return new ListCommand(inputCommand);
+        case ("back"): return new BackCommand(inputCommand);
+        case ("score"): return new ScoreCommand(inputCommand);
+        case ("reset"): return new ResetCommand(inputCommand);
         case ("help"): return new HelpCommand(inputCommand);
-        case ("overview"): return new OverviewCommand();
-        case ("listnote"): return new ListNoteCommand();
-        case ("reminder"): return new ReminderCommand();
+        case ("overview"): return new OverviewCommand(inputCommand);
+        case ("listnote"): return new ListNoteCommand(inputCommand);
+        case ("reminder"): return new ReminderCommand(inputCommand);
         case ("goto"): return new GoToCommand(inputCommand);
         case ("createnote"): return new CreateNoteCommand(inputCommand);
         case ("editnote"): return new EditNoteCommand(inputCommand);

--- a/src/main/java/javacake/commands/BackCommand.java
+++ b/src/main/java/javacake/commands/BackCommand.java
@@ -7,7 +7,15 @@ import javacake.ui.Ui;
 
 public class BackCommand extends Command {
 
-    public BackCommand() {
+
+    /**
+     * Constructor for BackCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand Back command from user.
+     * @throws CakeException If other parameter is appended to command.
+     */
+    public BackCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
         type = CmdType.BACK;
     }
 

--- a/src/main/java/javacake/commands/BackCommand.java
+++ b/src/main/java/javacake/commands/BackCommand.java
@@ -7,6 +7,9 @@ import javacake.ui.Ui;
 
 public class BackCommand extends Command {
 
+    public BackCommand() {
+
+    }
 
     /**
      * Constructor for BackCommand.

--- a/src/main/java/javacake/commands/Command.java
+++ b/src/main/java/javacake/commands/Command.java
@@ -21,6 +21,19 @@ public abstract class Command {
     public abstract String execute(Logic logic, Ui ui, StorageManager storageManager)
             throws CakeException;
 
+    /**
+     * Checks if input command has no other parameter appended.
+     * @param inputCommand Command input from user.
+     * @throws CakeException If parameter is appended to command.
+     */
+    void checksParam(String inputCommand) throws CakeException {
+        String bySpaces = "\\s+";
+        String[] subStrings = inputCommand.split(bySpaces);
+        if (subStrings.length > 1) {
+            throw new CakeException("Please ensure there is no parameter(s) for this command");
+        }
+    }
+
 
     /**
      * Method to check whether command is of type exit.

--- a/src/main/java/javacake/commands/Command.java
+++ b/src/main/java/javacake/commands/Command.java
@@ -26,7 +26,7 @@ public abstract class Command {
      * @param inputCommand Command input from user.
      * @throws CakeException If parameter is appended to command.
      */
-    void checksParam(String inputCommand) throws CakeException {
+    public static void checksParam(String inputCommand) throws CakeException {
         String bySpaces = "\\s+";
         String[] subStrings = inputCommand.split(bySpaces);
         if (subStrings.length > 1) {

--- a/src/main/java/javacake/commands/ExitCommand.java
+++ b/src/main/java/javacake/commands/ExitCommand.java
@@ -1,13 +1,22 @@
 package javacake.commands;
 
 import javacake.Logic;
+import javacake.exceptions.CakeException;
 import javacake.storage.Profile;
 import javacake.storage.StorageManager;
 import javacake.ui.Ui;
 import javacake.storage.Storage;
 
 public class ExitCommand extends Command {
-    public ExitCommand() {
+
+    /**
+     * Constructor for ExitCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand Exit command from user.
+     * @throws CakeException If other parameter is appended to command.
+     */
+    public ExitCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
         type = CmdType.EXIT;
     }
 

--- a/src/main/java/javacake/commands/ListCommand.java
+++ b/src/main/java/javacake/commands/ListCommand.java
@@ -6,7 +6,15 @@ import javacake.storage.StorageManager;
 import javacake.ui.Ui;
 
 public class ListCommand extends Command {
-    public ListCommand() {
+
+    /**
+     * Constructor for ListCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand List command from user.
+     * @throws CakeException If other parameter is appended to command.
+     */
+    public ListCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
         type = CmdType.LIST;
     }
 

--- a/src/main/java/javacake/commands/ListNoteCommand.java
+++ b/src/main/java/javacake/commands/ListNoteCommand.java
@@ -11,7 +11,14 @@ import java.util.ArrayList;
 
 public class ListNoteCommand extends Command {
 
-    public ListNoteCommand() {
+    /**
+     * Constructor for ListCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand List command from user.
+     * @throws CakeException If other parameter is appended to command.
+     */
+    public ListNoteCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
         type = CmdType.LISTNOTE;
     }
 

--- a/src/main/java/javacake/commands/ListNoteCommand.java
+++ b/src/main/java/javacake/commands/ListNoteCommand.java
@@ -11,6 +11,10 @@ import java.util.ArrayList;
 
 public class ListNoteCommand extends Command {
 
+    public ListNoteCommand() {
+
+    }
+
     /**
      * Constructor for ListCommand.
      * Checks that no parameters are included.

--- a/src/main/java/javacake/commands/OverviewCommand.java
+++ b/src/main/java/javacake/commands/OverviewCommand.java
@@ -30,9 +30,13 @@ public class OverviewCommand extends Command {
     private static int indentations = 5;
 
     /**
-     * Constructor for MegaListCommand.
+     * Constructor for OverviewCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand Overview command from user.
+     * @throws CakeException If other parameter is appended to command.
      */
-    public OverviewCommand() {
+    public OverviewCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
         type = CmdType.TREE;
     }
 

--- a/src/main/java/javacake/commands/ReminderCommand.java
+++ b/src/main/java/javacake/commands/ReminderCommand.java
@@ -12,6 +12,10 @@ import java.util.ArrayList;
 
 public class ReminderCommand extends Command {
 
+    public ReminderCommand() {
+
+    }
+
     /**
      * Constructor for ReminderCommand.
      * Checks that no parameters are included.

--- a/src/main/java/javacake/commands/ReminderCommand.java
+++ b/src/main/java/javacake/commands/ReminderCommand.java
@@ -1,6 +1,7 @@
 package javacake.commands;
 
 import javacake.Logic;
+import javacake.exceptions.CakeException;
 import javacake.storage.Profile;
 import javacake.storage.StorageManager;
 import javacake.ui.Ui;
@@ -10,7 +11,15 @@ import javacake.tasks.Task;
 import java.util.ArrayList;
 
 public class ReminderCommand extends Command {
-    public ReminderCommand() {
+
+    /**
+     * Constructor for ReminderCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand Reminder command from user.
+     * @throws CakeException If other parameter is appended to command.
+     */
+    public ReminderCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
         type = CmdType.REMIND;
     }
 

--- a/src/main/java/javacake/commands/ResetCommand.java
+++ b/src/main/java/javacake/commands/ResetCommand.java
@@ -6,6 +6,17 @@ import javacake.storage.StorageManager;
 import javacake.ui.Ui;
 
 public class ResetCommand extends Command {
+
+    /**
+     * Constructor for ResetCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand Reset command from user.
+     * @throws CakeException If other parameter is appended to command.
+     */
+    public ResetCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
+    }
+
     @Override
     public String execute(Logic logic, Ui ui, StorageManager storageManager) throws CakeException {
         return "Confirm reset and deletion of current Profile?\nType 'yes' to confirm\n"

--- a/src/main/java/javacake/commands/ScoreCommand.java
+++ b/src/main/java/javacake/commands/ScoreCommand.java
@@ -1,6 +1,7 @@
 package javacake.commands;
 
 import javacake.Logic;
+import javacake.exceptions.CakeException;
 import javacake.storage.StorageManager;
 import javacake.ui.Ui;
 
@@ -11,8 +12,14 @@ public class ScoreCommand extends Command {
     private int questionTypes = 4;
     private int totalQuestionQuantum = questionGrades * questionTypes;
 
-    public ScoreCommand() {
-
+    /**
+     * Constructor for ScoreCommand.
+     * Checks that no parameters are included.
+     * @param inputCommand Score command from user.
+     * @throws CakeException If other parameter is appended to command.
+     */
+    public ScoreCommand(String inputCommand) throws CakeException {
+        checksParam(inputCommand);
     }
 
     /**

--- a/src/main/java/javacake/quiz/ReviewSession.java
+++ b/src/main/java/javacake/quiz/ReviewSession.java
@@ -1,6 +1,7 @@
 package javacake.quiz;
 
 import javacake.commands.BackCommand;
+import javacake.commands.Command;
 import javacake.exceptions.CakeException;
 import javacake.Logic;
 import javacake.storage.StorageManager;
@@ -72,11 +73,12 @@ public class ReviewSession implements QuizManager {
             try {
                 Question question = answeredQuestions.getQuestionList().get(index);
                 ui.displayReview(question, index + 1, answeredQuestions.getQuestionList().size());
-                String next = ui.readCommand();
-                if (next.trim().equals("back")) {
+                String command = ui.readCommand();
+                if (command.trim().equals("back")) {
+                    //Command.checksParam(command);
                     isExitReview = true;
                 } else {
-                    index = Integer.parseInt(next) - 1;
+                    index = Integer.parseInt(command) - 1;
                 }
             } catch (IndexOutOfBoundsException e) {
                 ui.showError("Invalid index! Range of question: 1 - " + answeredQuestions.getQuestionList().size());

--- a/src/main/java/javacake/quiz/ReviewSession.java
+++ b/src/main/java/javacake/quiz/ReviewSession.java
@@ -1,7 +1,6 @@
 package javacake.quiz;
 
 import javacake.commands.BackCommand;
-import javacake.commands.Command;
 import javacake.exceptions.CakeException;
 import javacake.Logic;
 import javacake.storage.StorageManager;

--- a/src/test/java/ListCommandTest.java
+++ b/src/test/java/ListCommandTest.java
@@ -31,7 +31,7 @@ public class ListCommandTest {
             Logic logic = Logic.getInstance();
             Ui ui = new Ui();
             StorageManager sm = new StorageManager();
-            ListCommand lc = new ListCommand();
+            ListCommand lc = new ListCommand("list");
             String actualOutput = lc.execute(logic, ui, sm);
             assertEquals(expectedOutput.trim(), actualOutput.trim());
         } catch (CakeException e) {


### PR DESCRIPTION
+ Commands that do not require parameters will only accept command word itself.

E.g. `list` does not require any parameter. 
Hence, any string of words that is appended to the command will invoke an exception e.g. `list abc123`